### PR TITLE
Add UserByEmail query 

### DIFF
--- a/src/Operation/User.php
+++ b/src/Operation/User.php
@@ -4,6 +4,7 @@ namespace Lagoon\Operation;
 
 use Lagoon\Operation\LagoonOperationBase;
 use Lagoon\Query\Users\FetchAll;
+use Lagoon\Query\Users\UsersByEmail;
 use Lagoon\Query\Users\UsersBySshKey;
 use Lagoon\Mutation\User\Add;
 use Lagoon\Mutation\User\AddUserToProject;
@@ -17,6 +18,7 @@ class User extends LagoonOperationBase {
    * Naming constants to use throughout the class.
    */
   const SSH_KEY = 'find_ssh_key';
+  const EMAIL = 'find_email';
   const ADD = 'add';
   const ADD_TO_PROJECT = 'add_to_project';
   const FETCH_ALL = 'all';
@@ -26,6 +28,7 @@ class User extends LagoonOperationBase {
    */
   protected function bind() {
     $this->addQuery(self::SSH_KEY, UsersBySshKey::class)
+      ->addQuery(self::EMAIL, UsersByEmail::class)
       ->addQuery(self::FETCH_ALL, FetchAll::class)
       ->addMutation(self::ADD, Add::class)
       ->addMutation(self::ADD_TO_PROJECT, AddUserToProject::class)
@@ -88,4 +91,17 @@ class User extends LagoonOperationBase {
   public function all() {
     return $this->query(SELF::FETCH_ALL);
   }
+
+  /**
+   * Fetch a user by email address.
+   *
+   * @return Lagoon\LagoonQueryInterface
+   *   The lagoon query object.
+   */
+  public function withEmail($email) {
+    return $this->query(SELF::EMAIL, [
+      'email' => $email,
+    ]);
+  }
+
 }

--- a/src/Query/Users/UsersByEmail.php
+++ b/src/Query/Users/UsersByEmail.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Lagoon\Query\Users;
+
+use Lagoon\LagoonQueryBase;
+
+/**
+ * Update a project using the grpahql api.
+ */
+class UsersByEmail extends LagoonQueryBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function expectedKeys() {
+    return ['email'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function query() {
+    return <<<QUERY
+query FindByEmail(\$email: String!) {
+  userByEmail(email: \$email) {
+    %s
+  }
+}
+QUERY;
+  }
+}


### PR DESCRIPTION
In order to make the user registration feature of the Drupal module implementation of this API package work, we need a way to link existing Lagoon accounts to Drupal users.

## Current Workflow

1. Drupal user registers with email address already in LagoonAPI. 
2. SDK catches the error from LagoonAPI and shows it in the Drupal register form.
3. User cannot register for the Drupal site with that email address. 
4. Users cannot be linked without manually entering a Lagoon API user ID.

## Adding a LagoonAPI Feature

This feature does not exist in the LagoonAPI currently.  It has been requested by Lagoon users before.

This PR (of the PHP SDK) could be used to add this feature to Lagoon API SRC, because this repo's composer.json can be altered to include a branch of Lagoon API and can have tests against that.

- [ ] Find and paste links here to those conversations.

These steps can be taken to add a feature to both Lagoon API source and the PHP SDK source at the same time. They should be documented and included in this repo.

- [ ] Create a PR in https://github.com/amazeeio/lagoon/tree/main/services/api for the feature.
- [ ] Alter https://github.com/uselagoon/lagoon-php-sdk/blob/master/composer.json#L28 to reference the PR branch.
- [ ] Write a test that uses the query to ensure it works.
- [ ] Once passing, merge the Lagoon PR.
- [ ] Require the new version of lagoon in this repo's composer.json.
- [ ] Once passing, merge this PR.
