### PR TITLE
GuzzleHTTP 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   ],
   "require": {
     "php": ">=7",
-    "euautomation/graphql-client": "^0.2.0"
+    "euautomation/graphql-client": "dev-master"
   },
   "require-dev": {
     "couscous/couscous": "^1.7",


### PR DESCRIPTION
Hi,

I had to use this library in a project recently and it was using an old version of the graphql-client library that relied on GuzzleHTTP 6.x. This is quite an old release of Guzzle and it conflicted with the newer GuzzleHTTP 7.x I was using.

I've bumped the graphql-client to a newer version in this PR which does support 7.x of Guzzle. They unfortunately haven't made a release, so I've pointed it to `dev-master` for now. It does retain compatibility with Guzzle 6.x though so existing installs shouldn't be impacted. The SDK still appears to be working as expected with this new version.